### PR TITLE
feat(ui): 플러그인 설정 화면 UI 파일 분리, 만들기

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,26 @@
 import { App, Editor, MarkdownView, Modal, Notice, Plugin, PluginManifest, PluginSettingTab, Setting } from 'obsidian'
 import { GTask } from './models/GTask'
 import { GTaskMockDataSource } from './models/GTaskMockDataSource'
+import { SettingTab } from './settings/setting-tab'
 
 interface GTaskSyncPluginSettings {
-  mySetting: string
+  mySetting: string,
+  ownAuthenticationClient: boolean;
+	googleClientId: string;
+	googleClientSecret: string;
+	isLoggedIn: boolean;
+	useGoogleCalendarSync: boolean
+  googleRedirectUrl: string;
 }
 
 const DEFAULT_SETTINGS: GTaskSyncPluginSettings = {
   mySetting: 'default',
+  ownAuthenticationClient: true,
+	googleClientId: '',
+	googleClientSecret: '',
+  isLoggedIn: false,
+	useGoogleCalendarSync: true,
+  googleRedirectUrl: 'https://redirect.url',
 }
 
 export default class GTaskSyncPlugin extends Plugin {
@@ -71,7 +84,7 @@ export default class GTaskSyncPlugin extends Plugin {
     })
 
     // This adds a settings tab so the user can configure various aspects of the plugin
-    this.addSettingTab(new SampleSettingTab(this.app, this))
+    this.addSettingTab(new SettingTab(this.app, this))
 
     // If the plugin hooks up any global DOM events (on parts of the app that doesn't belong to this plugin)
     // Using this function will automatically remove the event listener when this plugin is disabled.
@@ -107,33 +120,5 @@ class SampleModal extends Modal {
   onClose() {
     const { contentEl } = this
     contentEl.empty()
-  }
-}
-
-class SampleSettingTab extends PluginSettingTab {
-  plugin: GTaskSyncPlugin
-
-  constructor(app: App, plugin: GTaskSyncPlugin) {
-    super(app, plugin)
-    this.plugin = plugin
-  }
-
-  display(): void {
-    const { containerEl } = this
-
-    containerEl.empty()
-
-    new Setting(containerEl)
-      .setName('Setting #1')
-      .setDesc("It's a secret")
-      .addText((text) =>
-        text
-          .setPlaceholder('Enter your secret')
-          .setValue(this.plugin.settings.mySetting)
-          .onChange(async (value) => {
-            this.plugin.settings.mySetting = value
-            await this.plugin.saveSettings()
-          }),
-      )
   }
 }

--- a/src/settings/setting-tab.ts
+++ b/src/settings/setting-tab.ts
@@ -1,0 +1,111 @@
+import { App, PluginSettingTab, Setting } from "obsidian";
+import GTaskSyncPlugin from "src/main";
+
+export class SettingTab extends PluginSettingTab {
+	plugin: GTaskSyncPlugin;
+
+	constructor(app: App, plugin: GTaskSyncPlugin) {
+		super(app, plugin);
+		this.plugin = plugin;
+	}
+
+    display(): void {
+		const { containerEl } = this;
+		containerEl.empty();
+
+        containerEl.createEl("h4", { text: "Settings for Sync-Todo Plugin" });
+        containerEl.createEl("h2", { text: "Restart Obsidian to apply your new settings" });
+
+        
+        new Setting(containerEl)
+			.setName("Use your own authentication client")
+			.setDesc("If you want to use your own authentication client, please check the documentation.")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.ownAuthenticationClient)
+					.onChange(async (value) => {
+						if (value === true) {
+							// 토글이 켜질 때
+
+						}
+						this.plugin.settings.ownAuthenticationClient = value;
+						await this.plugin.saveSettings();
+						this.display();
+					})
+			);
+
+        if (this.plugin.settings.ownAuthenticationClient) {
+
+			new Setting(containerEl)
+				.setName("Client Id")
+				.setDesc("Google client id")
+				.addText((text) =>
+					text
+						.setPlaceholder("Enter your client id")
+						.setValue(this.plugin.settings.googleClientId)
+						.onChange(async (value) => {
+							this.plugin.settings.googleClientId = value.trim();
+							await this.plugin.saveSettings();
+
+
+						})
+				);
+
+			new Setting(containerEl)
+				.setName("Client Secret")
+				.setDesc("Google client secret")
+				.addText((text) =>
+					text
+						.setPlaceholder("Enter your client secret")
+						.setValue(this.plugin.settings.googleClientSecret)
+						.onChange(async (value) => {
+							this.plugin.settings.googleClientSecret = value.trim();
+							await this.plugin.saveSettings();
+						})
+				);
+		}
+
+		new Setting(containerEl)
+			.setName("Google Login")
+			.addButton(button => {
+				button
+					.setButtonText(this.plugin.settings.isLoggedIn ? "Logout" : "Login")
+					.onClick(() => {
+						
+
+						this.hide();
+						this.display();
+					})
+			})
+
+		new Setting(containerEl)
+				.setName("Google Redirct url")
+				.setDesc("The url to the server where the oauth takes place")
+				.addText(text => {
+					text
+						.setValue(this.plugin.settings.googleRedirectUrl)
+						.onChange(async (value) => {
+
+
+							this.plugin.settings.googleRedirectUrl = value.trim();
+							await this.plugin.saveSettings();
+						})
+				})
+
+		new Setting(containerEl)
+			.setName("Google Calendar Integration")
+			.setDesc("Sync your tasks with Google Calendar")
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.useGoogleCalendarSync)
+				.onChange(async (state) => {
+					this.plugin.settings.useGoogleCalendarSync = state;
+					await this.plugin.saveSettings();
+
+
+					this.hide();
+					this.display();
+				});
+			});
+
+	}
+}


### PR DESCRIPTION
## 요약

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

main.ts 밖에서 settings를 관리하기 위해서 폴더 생성 했습니다.
SampleSettingTab에서 SettingTab으로 이름 변경 후 settings/setting-tab.ts 로 분리했습니다. 

Setting UI 중 OAuth 기능에 필요해 보이는 UI만 먼저 만들었습니다.
main.ts : GTaskSyncPluginSettings와 Default_settings에 설정에서 저장되는 정보 추가했습니다.

## PR 체크리스트

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 코드의 포맷팅이 전체적으로 올바르게 되어 있습니다.
- [ ] Lint 오류 등이 발생하지 않습니다.

## 스크린샷 (선택사항)
![스크린샷 2025-05-19 192948](https://github.com/user-attachments/assets/4783eed2-3296-4886-8722-08bbe12cd14b)


## 비고

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
OAuth Flow 설정에서 필요해 보이는 ui는 완성했는데, 혹시 추가적으로 
Setting Tab에 들어가야 할 정보 말씀해주시면 업데이트 하도록 하겠습니다.

<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
