### PR TITLE
[OBS-22] Turn into Google Task 버튼을 클릭했을 때, 드래그한 특정 텍스트를 인식할 수 있게 하기

### DIFF
--- a/src/commands/TurnIntoGoogleTaskCommand.ts
+++ b/src/commands/TurnIntoGoogleTaskCommand.ts
@@ -1,11 +1,19 @@
-import { Plugin } from 'obsidian';
+import { Editor, MarkdownView, Notice, Plugin } from 'obsidian';
 
 export function registerTurnIntoGoogleTaskCommand(plugin: Plugin) {
   plugin.addCommand({
     id: 'turn-into-google-task',
     name: 'Turn into Google Task',
-    callback: () => {
-      console.log('🧪 Turn into Google Task 명령 실행');
+    editorCallback: (editor: Editor, view: MarkdownView) => {
+      const selectedText = editor.getSelection().trim();
+
+      if (!selectedText) {
+        new Notice('Please drag and select the text first');
+        return;
+      }
+
+      console.log('선택된 문구:', selectedText);
+      //드래그한 selectedText Control하는 부분
     },
   });
 }


### PR DESCRIPTION
## 요약

'Turn into Google Task 버튼을 눌렀을 때, 특정 텍스트 인식'
[OBS - 21](https://linear.app/obsidian-tasks-sync-plugin/issue/OBS-22/turn-into-google-task-%EB%B2%84%ED%8A%BC%EC%9D%84-%ED%81%B4%EB%A6%AD%ED%96%88%EC%9D%84-%EB%95%8C-%EB%93%9C%EB%9E%98%EA%B7%B8%ED%95%9C-%ED%8A%B9%EC%A0%95-%ED%85%8D%EC%8A%A4%ED%8A%B8%EB%A5%BC-%EC%9D%B8%EC%8B%9D%ED%95%A0-%EC%88%98-%EC%9E%88%EA%B2%8C-%ED%95%98%EA%B8%B0)

### 주요 변경 사항
- registerTurnIntoGoogleTaskCommand 함수 내에서, 드래그한 문구를 인식할 수 있도록 수정하였음.

## PR 체크리스트

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ o ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ o ] 코드의 포맷팅이 전체적으로 올바르게 되어 있습니다.
- [ o ] Lint 오류 등이 발생하지 않습니다.
