### PR TITLE
[OBS-54]  GTask -> Obsidian 업데이트되는 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 - Google Tasks에서 변경된 Task 상태를 Obsidian 문서에 반영
 - Obsidian에서 Task를 수정하면 Google Tasks에도 자동 반영
-- 마크다운 문서 내 Task(`- [ ] [Task Title](gtask:task-id)`)를 Google Tasks와 양방향 동기화
+- 마크다운 문서 내 Task(`- [ ] [Task Title](gtask:taskId:tasklistId)`)를 Google Tasks와 양방향 동기화
 - 명령어(Command Palette)를 통한 Task 동기화/생성 지원
 - Google OAuth2 인증 지원
 
@@ -61,8 +61,8 @@
 ## 마크다운 Task 포맷
 
 ```markdown
-- [ ] [Task 제목](gtask:task-list-id:task-id)
-- [x] [완료된 Task](gtask:task-list-id:task-id)
+- [ ] [Task 제목](gtask:taskId:taskListId)
+- [x] [완료된 Task](gtask:taskId:taskListId)
 ```
 
 - `[ ]` : 미완료, `[x]` : 완료

--- a/src/controllers/TaskController.ts
+++ b/src/controllers/TaskController.ts
@@ -1,25 +1,25 @@
 import { debounce } from 'es-toolkit';
 import { App, TFile } from 'obsidian';
-import { TaskRepository } from '../repositories/TaskRepository';
+import { FileRepository } from 'src/repositories/FileRepository';
 
 export class TaskController {
   private abortController = new AbortController();
 
   constructor(
     private readonly app: App,
-    private readonly repository: TaskRepository,
+    private readonly fileRepo: FileRepository,
   ) {}
 
   init(): void {
     const fileOpenEvent = this.app.workspace.on('file-open', async (file: TFile | null) => {
-      if (file) {
-        await this.repository.scanFile(file);
+      if (file != null) {
+        await this.fileRepo.get(file.path)?.scan();
       }
     });
 
     const fileSaveEvent = this.app.vault.on(
       'modify',
-      debounce((file) => this.repository.scanFile(file), 300, { signal: this.abortController.signal }),
+      debounce((file) => this.fileRepo.get(file.path)?.scan(), 300, { signal: this.abortController.signal }),
     );
 
     this.abortController.signal.addEventListener('abort', () => {

--- a/src/libs/regexp.ts
+++ b/src/libs/regexp.ts
@@ -21,8 +21,3 @@ export function getGTaskLineMeta(line: string): GTaskLineMeta | null {
   }
   return null;
 }
-
-export function createGTaskLine(meta: GTaskLineMeta): string {
-  const status = meta.status === 'completed' ? 'x' : ' ';
-  return `- [${status}] [${meta.title}](gtask:${meta.tasklistId}:${meta.id})`;
-}

--- a/src/libs/regexp.ts
+++ b/src/libs/regexp.ts
@@ -15,8 +15,8 @@ export function getGTaskLineMeta(line: string): GTaskLineMeta | null {
     return {
       status: match[1] === 'x' ? 'completed' : 'needsAction',
       title: match[2] as string,
-      tasklistId: match[3] as string,
-      id: match[4] as string,
+      id: match[3] as string,
+      tasklistId: match[4] as string,
     };
   }
   return null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,16 +38,17 @@ export default class GTaskSyncPlugin extends Plugin {
   constructor(app: App, manifest: PluginManifest) {
     super(app, manifest);
 
-    this.remote = new GTaskRemote(app, this.settings);
-
-    this.fileRepo = new FileRepository(app, this.remote);
-    this.taskController = new TaskController(app, this.fileRepo);
-
     (window as any).test = this;
   }
 
   async onload() {
+    //initialize
     await this.loadSettings();
+    this.remote = new GTaskRemote(this.app, this.settings);
+    this.fileRepo = new FileRepository(this.app, this.remote);
+    this.taskController = new TaskController(this.app, this.fileRepo);
+
+    await this.fileRepo.initialize();
 
     // 옵시디언에서 특정한 텍스트 타입 인식하게 하기 , SYNC 버튼 추가
     this.extensions.push(createSyncFromRemoteExtension(this, this.fileRepo));

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,7 @@ export default class GTaskSyncPlugin extends Plugin {
     await this.fileRepo.initialize();
 
     // 옵시디언에서 특정한 텍스트 타입 인식하게 하기 , SYNC 버튼 추가
-    this.extensions.push(createSyncFromRemoteExtension(this, this.fileRepo));
+    this.extensions.push(createSyncFromRemoteExtension(this, this.fileRepo, this.remote));
 
     const ribbonIconEl = this.addRibbonIcon('dice', 'Sample Plugin', (evt: MouseEvent) => {
       // Called when the user clicks the icon.

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,10 +28,10 @@ const DEFAULT_SETTINGS: GTaskSyncPluginSettings = {
 
 export default class GTaskSyncPlugin extends Plugin {
   private remote: GTaskRemote;
-  private settings: GTaskSyncPluginSettings;
-
   private fileRepo: FileRepository;
   private taskController: TaskController;
+
+  settings: GTaskSyncPluginSettings;
 
   extensions: Extension[] = [];
 
@@ -50,7 +50,7 @@ export default class GTaskSyncPlugin extends Plugin {
     await this.loadSettings();
 
     // 옵시디언에서 특정한 텍스트 타입 인식하게 하기 , SYNC 버튼 추가
-    this.extensions.push(createSyncFromRemoteExtension(this));
+    this.extensions.push(createSyncFromRemoteExtension(this, this.fileRepo));
 
     const ribbonIconEl = this.addRibbonIcon('dice', 'Sample Plugin', (evt: MouseEvent) => {
       // Called when the user clicks the icon.
@@ -101,7 +101,7 @@ export default class GTaskSyncPlugin extends Plugin {
     });
 
     // This adds a settings tab so the user can configure various aspects of the plugin
-    this.addSettingTab(new SettingTab(this.app, this));
+    this.addSettingTab(new SettingTab(this.app, this, this.remote));
 
     // When registering intervals, this function will automatically clear the interval when the plugin is disabled.
     this.registerInterval(window.setInterval(() => console.log('setInterval'), 5 * 60 * 1000));

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { App, Editor, MarkdownView, Modal, Notice, Plugin, PluginManifest } from
 import { registerTurnIntoGoogleTaskCommand } from './commands/TurnIntoGoogleTaskCommand';
 import { TaskController } from './controllers/TaskController';
 import { GTaskRemote } from './models/remote/gtask/GTaskRemote';
-import { TaskRepository } from './repositories/TaskRepository';
+import { FileRepository } from './repositories/FileRepository';
 import { SettingTab } from './views/SettingTab';
 import { createSyncFromRemoteExtension } from './views/SyncFromRemoteButton';
 
@@ -27,21 +27,21 @@ const DEFAULT_SETTINGS: GTaskSyncPluginSettings = {
 };
 
 export default class GTaskSyncPlugin extends Plugin {
-  settings: GTaskSyncPluginSettings;
+  private remote: GTaskRemote;
+  private settings: GTaskSyncPluginSettings;
 
-  remote: GTaskRemote;
-  taskRepo: TaskRepository;
-  taskController: TaskController;
+  private fileRepo: FileRepository;
+  private taskController: TaskController;
 
   extensions: Extension[] = [];
 
   constructor(app: App, manifest: PluginManifest) {
     super(app, manifest);
 
-    this.remote = new GTaskRemote(this);
+    this.remote = new GTaskRemote(app, this.settings);
 
-    this.taskRepo = new TaskRepository(app, this.remote);
-    this.taskController = new TaskController(app, this.taskRepo);
+    this.fileRepo = new FileRepository(app, this.remote);
+    this.taskController = new TaskController(app, this.fileRepo);
 
     (window as any).test = this;
   }

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -23,6 +23,6 @@ export class Task {
 
   toMarkdown(): string {
     const status = this.status === 'completed' ? 'x' : ' ';
-    return `- [${status}] [${this.title}](gtask:${this.id})`;
+    return `- [${status}] [${this.title}](gtask:${this.tasklistId}:${this.id})`;
   }
 }

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -23,7 +23,7 @@ export class Task {
 
   toMarkdown(): string {
     const status = this.status === 'completed' ? 'x' : ' ';
-    return `- [${status}] [${this.title}](gtask:${this.getIdentifier})`;
+    return `- [${status}] [${this.title}](gtask:${this.getIdentifier()})`;
   }
 
   getIdentifier(): string {

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -23,6 +23,10 @@ export class Task {
 
   toMarkdown(): string {
     const status = this.status === 'completed' ? 'x' : ' ';
-    return `- [${status}] [${this.title}](gtask:${this.tasklistId}:${this.id})`;
+    return `- [${status}] [${this.title}](gtask:${this.getIdentifier})`;
+  }
+
+  getIdentifier(): string {
+    return `${this.id}:${this.tasklistId}`;
   }
 }

--- a/src/models/remote/GTask/GTaskMockRemote.ts
+++ b/src/models/remote/GTask/GTaskMockRemote.ts
@@ -71,6 +71,10 @@ export class GTaskMockRemote implements Remote {
     ]);
   }
 
+  async authorize(): Promise<void> {
+    console.log('Mock authorization successful');
+  }
+
   get(id: string, tasklistId: string) {
     const item = this.mockedItemsMap.get(id);
 

--- a/src/models/remote/GTask/GtaskRemote.ts
+++ b/src/models/remote/GTask/GtaskRemote.ts
@@ -1,7 +1,7 @@
 import { assert } from 'es-toolkit';
 import { google, tasks_v1 } from 'googleapis';
-import { Notice } from 'obsidian';
-import GTaskSyncPlugin from 'src/main';
+import { App, Notice } from 'obsidian';
+import { GTaskSyncPluginSettings } from 'src/main';
 import { Task } from '../../Task';
 import { Remote } from '../Remote';
 import { GTaskAuthorization } from './GTaskAuthorization';
@@ -10,18 +10,17 @@ export class GTaskRemote implements Remote {
   private _auth?: GTaskAuthorization;
   private _client?: tasks_v1.Tasks;
 
-  constructor(private plugin: GTaskSyncPlugin) {}
+  constructor(
+    private app: App,
+    private settings: GTaskSyncPluginSettings,
+  ) {}
 
   async init() {
-    if (this.plugin.settings.googleClientId == null || this.plugin.settings.googleClientSecret == null) {
+    if (this.settings.googleClientId == null || this.settings.googleClientSecret == null) {
       return;
     }
 
-    this._auth = new GTaskAuthorization(
-      this.plugin.app,
-      this.plugin.settings.googleClientId,
-      this.plugin.settings.googleClientSecret,
-    );
+    this._auth = new GTaskAuthorization(this.app, this.settings.googleClientId, this.settings.googleClientSecret);
     this._client = google.tasks({
       version: 'v1',
       auth: this._auth.getAuthClient(),

--- a/src/models/remote/Remote.ts
+++ b/src/models/remote/Remote.ts
@@ -3,4 +3,5 @@ import { Task } from '../Task';
 export interface Remote {
   get(id: string, tasklistId: string): Promise<Task>;
   update(id: string, tasklistId: string, from: Task): Promise<void>;
+  authorize(): Promise<void>;
 }

--- a/src/repositories/FileRepository.ts
+++ b/src/repositories/FileRepository.ts
@@ -1,23 +1,56 @@
 import { App, TFile } from 'obsidian';
 import { getGTaskLineMeta } from 'src/libs/regexp';
 import { Remote } from 'src/models/remote/Remote';
-import { Task } from '../models/Task';
+import { Task } from 'src/models/Task';
+
+export class FileRepository {
+  private files: Map<string, File> = new Map();
+
+  constructor(
+    private app: App,
+    private remote: Remote,
+  ) {}
+
+  get(path: string): File | undefined {
+    const file = this.files.get(path);
+
+    if (file == null) {
+      const tFile = this.app.vault.getFileByPath(path);
+      if (tFile == null) {
+        return undefined;
+      }
+
+      const file = new File(this.app, this.remote, tFile);
+      this.files.set(path, file);
+    }
+
+    return file;
+  }
+}
 
 interface ScanFileResult {
   added: Task[];
   updated: Task[];
 }
 
-export class TaskRepository {
-  private tasksByFilePath: Map<string, Map<string, Task>> = new Map();
+//taskId : tasklistId
+type TaskKey = `${string}:${string}`;
+
+export class File {
+  private tasks: Map<TaskKey, Task> = new Map();
 
   constructor(
-    private readonly app: App,
+    private app: App,
     private remote: Remote,
+    private file: TFile,
   ) {}
 
-  async scanFile(file: TFile): Promise<ScanFileResult> {
-    const content = await this.app.vault.read(file);
+  getTask(id: string, tasklistId: string): Task | undefined {
+    return this.tasks.get(`${id}:${tasklistId}`);
+  }
+
+  async scan(): Promise<void> {
+    const content = await this.app.vault.read(this.file);
     const lines = content.split('\n');
 
     const result: ScanFileResult = {
@@ -25,14 +58,12 @@ export class TaskRepository {
       updated: [],
     };
 
-    const tasksByFilePath = this.getTasksByFilePath(file.path);
-
     for (const line of lines) {
       const meta = getGTaskLineMeta(line);
 
       if (meta != null) {
         const { status, title, tasklistId, id } = meta;
-        const cached = tasksByFilePath.get(id);
+        const cached = this.tasks.get(`${id}:${tasklistId}`);
 
         if (cached != null) {
           const isStatusUpdated = cached.status !== status;
@@ -47,34 +78,18 @@ export class TaskRepository {
         } else {
           const task = new Task(id, tasklistId, title, status);
 
-          tasksByFilePath.set(id, task);
+          this.tasks.set(`${id}:${tasklistId}`, task);
           result.added.push(task);
         }
       }
     }
 
-    for (const task of tasksByFilePath.values()) {
+    for (const task of this.tasks.values()) {
       if (!lines.some((line) => line.includes(`gtask:${task.tasklistId}:${task.id}`))) {
-        tasksByFilePath.delete(task.id);
+        this.tasks.delete(`${task.id}:${task.tasklistId}`);
       }
     }
 
     await Promise.all(result.updated.map((task) => this.remote.update(task.id, task.tasklistId, task)));
-    return result;
-  }
-
-  async syncWithDataSource(): Promise<void> {
-    throw new Error('Not implemented');
-  }
-
-  private getTasksByFilePath(filePath: string): Map<string, Task> {
-    let tasksByFilePath = this.tasksByFilePath.get(filePath);
-
-    if (tasksByFilePath == null) {
-      tasksByFilePath = new Map();
-      this.tasksByFilePath.set(filePath, tasksByFilePath);
-    }
-
-    return tasksByFilePath;
   }
 }

--- a/src/repositories/FileRepository.ts
+++ b/src/repositories/FileRepository.ts
@@ -26,6 +26,26 @@ export class FileRepository {
 
     return file;
   }
+
+  async initialize(): Promise<void> {
+    const markdownFiles = this.app.vault.getMarkdownFiles();
+    const batchSize = 20;
+
+    for (let i = 0; i < markdownFiles.length; i += batchSize) {
+      const batch = markdownFiles.slice(i, i + batchSize);
+      await Promise.all(
+        batch.map(async (tFile) => {
+          const file = new File(this.app, this.remote, tFile);
+          await file.initialize();
+
+          if (file.hasAnyTask()) {
+            this.files.set(tFile.path, file);
+          }
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
 }
 
 interface ScanFileResult {
@@ -44,6 +64,22 @@ export class File {
     private remote: Remote,
     private file: TFile,
   ) {}
+
+  async initialize(): Promise<void> {
+    const content = await this.app.vault.read(this.file);
+    const lines = content.split('\n');
+
+    for (const line of lines) {
+      const meta = getGTaskLineMeta(line);
+
+      if (meta != null) {
+        const { status, title, tasklistId, id } = meta;
+        const task = new Task(id, tasklistId, title, status);
+
+        this.tasks.set(`${id}:${tasklistId}`, task);
+      }
+    }
+  }
 
   getTask(id: string, tasklistId: string): Task | undefined {
     return this.tasks.get(`${id}:${tasklistId}`);
@@ -84,12 +120,17 @@ export class File {
       }
     }
 
+    // iterator 순회중에 중간에 삭제하는 것은 위험하므로, 추후 로직 수정 필요
     for (const task of this.tasks.values()) {
-      if (!lines.some((line) => line.includes(`gtask:${task.tasklistId}:${task.id}`))) {
+      if (!lines.some((line) => line.includes(`gtask:${task.id}:${task.tasklistId}`))) {
         this.tasks.delete(`${task.id}:${task.tasklistId}`);
       }
     }
 
     await Promise.all(result.updated.map((task) => this.remote.update(task.id, task.tasklistId, task)));
+  }
+
+  hasAnyTask(): boolean {
+    return this.tasks.size > 0;
   }
 }

--- a/src/views/SettingTab.ts
+++ b/src/views/SettingTab.ts
@@ -1,12 +1,15 @@
 import { App, PluginSettingTab, Setting } from 'obsidian';
 import GTaskSyncPlugin, { GTaskSyncPluginSettings } from 'src/main';
+import { Remote } from 'src/models/remote/Remote';
 
 export class SettingTab extends PluginSettingTab {
   private plugin: GTaskSyncPlugin;
+  private remote: Remote;
 
-  constructor(app: App, plugin: GTaskSyncPlugin) {
+  constructor(app: App, plugin: GTaskSyncPlugin, remote: Remote) {
     super(app, plugin);
     this.plugin = plugin;
+    this.remote = remote;
   }
 
   display(): void {
@@ -55,7 +58,7 @@ export class SettingTab extends PluginSettingTab {
       button.setButtonText(this.plugin.settings.isLoggedIn ? 'Logout' : 'Login').onClick(async () => {
         this.hide();
         this.display();
-        await this.plugin.remote.authorize();
+        await this.remote.authorize();
       });
     });
   }

--- a/src/views/SyncFromRemoteButton.ts
+++ b/src/views/SyncFromRemoteButton.ts
@@ -123,7 +123,7 @@ class SyncFromRemoteWidget extends WidgetType {
   }
 }
 
-export const createSyncFromRemoteExtension = (plugin: GTaskSyncPlugin): Extension => {
+export const createSyncFromRemoteExtension = (plugin: GTaskSyncPlugin, fileRepo: FileRepository): Extension => {
   return [
     EditorView.theme(
       {
@@ -154,7 +154,7 @@ export const createSyncFromRemoteExtension = (plugin: GTaskSyncPlugin): Extensio
               pos + line.length,
               pos + line.length,
               Decoration.widget({
-                widget: SyncFromRemoteWidget.create(meta, index, plugin),
+                widget: SyncFromRemoteWidget.create(meta, index, plugin.app.workspace, fileRepo),
                 side: 1,
               }),
             );

--- a/src/views/SyncFromRemoteButton.ts
+++ b/src/views/SyncFromRemoteButton.ts
@@ -1,7 +1,7 @@
 import { Extension, RangeSetBuilder, StateField } from '@codemirror/state';
 import { Decoration, EditorView, WidgetType } from '@codemirror/view';
 import { MarkdownView, Notice } from 'obsidian';
-import { createGTaskLine, getGTaskLineMeta, GTaskLineMeta } from 'src/libs/regexp';
+import { getGTaskLineMeta, GTaskLineMeta } from 'src/libs/regexp';
 import GTaskSyncPlugin from 'src/main';
 import { TaskRepository } from 'src/repositories/TaskRepository';
 
@@ -78,13 +78,11 @@ class SyncFromRemoteWidget extends WidgetType {
 
       try {
         const task = await this.plugin.remote.get(this.meta.id, this.meta.tasklistId);
-        const newLine = createGTaskLine({
-          ...task,
-          tasklistId: this.meta.tasklistId,
-        });
 
         task.setTitle(this.meta.title);
         task.setStatus(this.meta.status);
+
+        const newLine = task.toMarkdown();
 
         markdownView.editor.setLine(this.index, newLine);
         new Notice(`동기화됨`);

--- a/src/views/SyncFromRemoteButton.ts
+++ b/src/views/SyncFromRemoteButton.ts
@@ -3,6 +3,7 @@ import { Decoration, EditorView, WidgetType } from '@codemirror/view';
 import { MarkdownView, Notice } from 'obsidian';
 import { createGTaskLine, getGTaskLineMeta, GTaskLineMeta } from 'src/libs/regexp';
 import GTaskSyncPlugin from 'src/main';
+import { TaskRepository } from 'src/repositories/TaskRepository';
 
 // 위젯 캐시를 위한 클래스
 class WidgetCache {
@@ -26,6 +27,7 @@ class SyncFromRemoteWidget extends WidgetType {
   private static widgetIdCounter = 0;
   public readonly widgetId: string;
   private button: HTMLButtonElement | null = null;
+  private taskRepo: TaskRepository;
 
   constructor(
     private meta: GTaskLineMeta,
@@ -34,6 +36,7 @@ class SyncFromRemoteWidget extends WidgetType {
   ) {
     super();
     this.widgetId = `sync-widget-${SyncFromRemoteWidget.widgetIdCounter++}`;
+    this.taskRepo = plugin.taskRepo;
   }
 
   static create(meta: GTaskLineMeta, index: number, plugin: GTaskSyncPlugin): SyncFromRemoteWidget {
@@ -79,6 +82,9 @@ class SyncFromRemoteWidget extends WidgetType {
           ...task,
           tasklistId: this.meta.tasklistId,
         });
+
+        task.setTitle(this.meta.title);
+        task.setStatus(this.meta.status);
 
         markdownView.editor.setLine(this.index, newLine);
         new Notice(`동기화됨`);


### PR DESCRIPTION
## 요약

- task의 key가 {taskId:taskListId} 형식이 되도록 통일했습니다.
- 초기에 옵시디언을 킬 때 FileRepository를 초기화하도록 했습니다.(vault 내의 존재하는 task읽어서 저장)
- GTask 에서 SyncFromRemote를 눌렀을 떄 업데이트 되는 기능을 추가했습니다.

## PR 체크리스트

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드의 포맷팅이 전체적으로 올바르게 되어 있습니다.
- [x] Lint 오류 등이 발생하지 않습니다.

## 스크린샷 (선택사항)

- 테스트 영상 Uploading Screen Recording 2025-06-05 at 16.00.47.mov…

## 비고

현재 gtask:taskId:taskListId 로 구성되는 게 너무 흩어져있어서 통일이 안된 것들이 좀 있었어요.
이거 나중에 별도의 클래스로 빼서 그걸 통일하게 만들어야할것 같아요